### PR TITLE
Support both NodeJS and Browser rollup

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -15,6 +15,7 @@
     "@autoview/interface": "workspace:^",
     "@rollup/browser": "^4.34.9",
     "@samchon/openapi": "^3.0.0",
+    "rollup": "^4.34.1",
     "serialize-error": "4.1.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",

--- a/packages/compiler/src/compilers/RollupBundler.ts
+++ b/packages/compiler/src/compilers/RollupBundler.ts
@@ -1,27 +1,30 @@
-import { RollupBuild, rollup } from "@rollup/browser";
-import { VariadicSingleton } from "tstl";
+import { rollup as browserRollUp } from "@rollup/browser";
+import { RollupBuild, rollup as nodeRollUp } from "rollup";
+import { VariadicSingleton, is_node } from "tstl";
 
 export namespace RollupBundler {
   export const build = async (script: string): Promise<string> => {
     const modules: Record<string, string> = {
       "index.js": script,
     };
-    const builder: RollupBuild = await rollup({
-      input: "index.js",
-      plugins: [
-        {
-          name: "virtual",
-          resolveId: (id) => {
-            if (id in modules) return id;
-            return new URL(id, "https://esm.sh").href;
+    const builder: RollupBuild = await (is_node() ? nodeRollUp : browserRollUp)(
+      {
+        input: "index.js",
+        plugins: [
+          {
+            name: "virtual",
+            resolveId: (id) => {
+              if (id in modules) return id;
+              return new URL(id, "https://esm.sh").href;
+            },
+            load: (id) => {
+              if (id in modules) return modules[id];
+              return esm.get(id);
+            },
           },
-          load: (id) => {
-            if (id in modules) return modules[id];
-            return esm.get(id);
-          },
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     const { output } = await builder.generate({
       format: "iife",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@samchon/openapi':
         specifier: ^3.0.0
         version: 3.1.0
+      rollup:
+        specifier: ^4.34.1
+        version: 4.36.0
       serialize-error:
         specifier: 4.1.0
         version: 4.1.0


### PR DESCRIPTION
This pull request includes updates to the dependencies and modifications to the `RollupBundler` to support both browser and Node.js environments. The most important changes include updating the `rollup` dependency and modifying the `RollupBundler` to conditionally use the appropriate `rollup` instance based on the environment.

Dependency updates:

* [`packages/compiler/package.json`](diffhunk://#diff-11f1c967e7b88e8bb1ad9292bc77da6ad6ac034c264ce56eed069eb1e19865deR18): Added `rollup` version `^4.34.1` to the dependencies.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR99-R101): Added `rollup` with specifier `^4.34.1` and version `4.36.0`.

Code modifications for environment support:

* `packages/compiler/src/compilers/RollupBundler.ts`: 
  * Changed imports to conditionally import `rollup` from either `@rollup/browser` or `rollup` based on the environment.
  * Modified the `build` method to use the appropriate `rollup` instance (`nodeRollUp` or `browserRollUp`) based on whether the code is running in a Node.js environment.