### PR TITLE
Fix wrong input type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@autoview/station",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Automatic viewer components renderer by JSON schema and AI agent",
   "repository": {
     "type": "git",

--- a/packages/compiler/src/programmers/AutoViewTransformerProgrammer.ts
+++ b/packages/compiler/src/programmers/AutoViewTransformerProgrammer.ts
@@ -29,10 +29,7 @@ export namespace AutoViewTransformerProgrammer {
             ts.factory.createIdentifier("$input"),
             undefined,
             ts.factory.createTypeReferenceNode(
-              ts.factory.createQualifiedName(
-                ts.factory.createIdentifier("IAutoView"),
-                ts.factory.createIdentifier("IAutoViewComponentProps"),
-              ),
+              ts.factory.createIdentifier("IAutoViewTransformerInputType"),
               undefined,
             ),
           ),


### PR DESCRIPTION
This pull request includes a version update and a type reference change in the AutoView Transformer Programmer.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `5.1.0` to `5.1.1`.

Type reference change:

* [`packages/compiler/src/programmers/AutoViewTransformerProgrammer.ts`](diffhunk://#diff-b0cb306d722b5e3de535a96203df256dca8919fbbfcec1069b4b6041f7b2224fL32-R32): Changed the type reference from `IAutoView.IAutoViewComponentProps` to `IAutoViewTransformerInputType`.