### PR TITLE
Bump up dependencies, and fix `uint32` problem.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@autoview/station",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Automatic viewer components renderer by JSON schema and AI agent",
   "repository": {
     "type": "git",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -38,9 +38,9 @@
   "dependencies": {
     "@autoview/compiler": "workspace:^",
     "@autoview/interface": "workspace:^",
-    "@samchon/openapi": "^3.2.4",
+    "@samchon/openapi": "^4.0.0",
     "jsonpath-plus": "^10.3.0",
     "openai": "^4.90.0",
-    "typia": "^8.1.1"
+    "typia": "^9.0.1"
   }
 }

--- a/packages/compiler-browser-test/package.json
+++ b/packages/compiler-browser-test/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^19.0.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^8.1.1"
+    "typia": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@autoview/interface": "workspace:^",
-    "@samchon/openapi": "^3.2.4",
+    "@samchon/openapi": "^4.0.0",
     "serialize-error": "4.1.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^8.1.1"
+    "typia": "^9.0.1"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/packages/compiler/src/programmers/AutoViewSchemaProgrammer.ts
+++ b/packages/compiler/src/programmers/AutoViewSchemaProgrammer.ts
@@ -111,8 +111,11 @@ export namespace AutoViewSchemaProgrammer {
   ): ts.TypeNode =>
     writeNumeric(() => [
       TypeFactory.keyword("number"),
-      ctx.importer.tag("Type", "int32"),
-    ])(ctx, schema);
+      ctx.importer.tag("Type", schema.minimum === 0 ? "uint32" : "int32"),
+    ])(ctx, {
+      ...schema,
+      minimum: schema.minimum === 0 ? undefined : schema.minimum,
+    });
 
   const writeNumber = (
     ctx: IAutoViewProgrammerContext,

--- a/packages/compiler/src/programmers/AutoViewSchemaProgrammer.ts
+++ b/packages/compiler/src/programmers/AutoViewSchemaProgrammer.ts
@@ -133,18 +133,16 @@ export namespace AutoViewSchemaProgrammer {
       if (schema.default !== undefined)
         intersection.push(ctx.importer.tag("Default", schema.default));
       if (schema.minimum !== undefined)
-        intersection.push(
-          ctx.importer.tag(
-            schema.exclusiveMinimum ? "ExclusiveMinimum" : "Minimum",
-            schema.minimum,
-          ),
-        );
+        intersection.push(ctx.importer.tag("Minimum", schema.minimum));
       if (schema.maximum !== undefined)
+        intersection.push(ctx.importer.tag("Maximum", schema.maximum));
+      if (typeof schema.exclusiveMinimum === "number")
         intersection.push(
-          ctx.importer.tag(
-            schema.exclusiveMaximum ? "ExclusiveMaximum" : "Maximum",
-            schema.maximum,
-          ),
+          ctx.importer.tag("ExclusiveMinimum", schema.exclusiveMinimum),
+        );
+      if (typeof schema.exclusiveMaximum === "number")
+        intersection.push(
+          ctx.importer.tag("ExclusiveMaximum", schema.exclusiveMaximum),
         );
       if (schema.multipleOf !== undefined)
         intersection.push(ctx.importer.tag("MultipleOf", schema.multipleOf));

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -23,8 +23,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@samchon/openapi": "^3.2.4",
-    "typia": "^8.1.1"
+    "@samchon/openapi": "^4.0.0",
+    "typia": "^9.0.1"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: workspace:^
         version: link:../interface
       '@samchon/openapi':
-        specifier: ^3.2.4
-        version: 3.2.4
+        specifier: ^4.0.0
+        version: 4.0.0
       jsonpath-plus:
         specifier: ^10.3.0
         version: 10.3.0
@@ -51,8 +51,8 @@ importers:
         specifier: ^4.90.0
         version: 4.90.0(ws@8.18.1)(zod@3.24.2)
       typia:
-        specifier: ^8.1.1
-        version: 8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2)
+        specifier: ^9.0.1
+        version: 9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.13.9
@@ -88,8 +88,8 @@ importers:
         specifier: workspace:^
         version: link:../interface
       '@samchon/openapi':
-        specifier: ^3.2.4
-        version: 3.2.4
+        specifier: ^4.0.0
+        version: 4.0.0
       serialize-error:
         specifier: 4.1.0
         version: 4.1.0
@@ -100,8 +100,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.1.1
-        version: 8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2)
+        specifier: ^9.0.1
+        version: 9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -134,15 +134,15 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.1.1
-        version: 8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2)
+        specifier: ^9.0.1
+        version: 9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.22.0
       '@ryoppippi/unplugin-typia':
         specifier: ^2.1.4
-        version: 2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.11
@@ -180,11 +180,11 @@ importers:
   packages/interface:
     dependencies:
       '@samchon/openapi':
-        specifier: ^3.2.4
-        version: 3.2.4
+        specifier: ^4.0.0
+        version: 4.0.0
       typia:
-        specifier: ^8.1.1
-        version: 8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2)
+        specifier: ^9.0.1
+        version: 9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
     devDependencies:
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.7.2
@@ -334,8 +334,8 @@ importers:
         specifier: ^0.8.2
         version: 0.8.3
       '@samchon/openapi':
-        specifier: ^3.2.4
-        version: 3.2.4
+        specifier: ^4.0.0
+        version: 4.0.0
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -358,8 +358,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^8.1.1
-        version: 8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2)
+        specifier: ^9.0.1
+        version: 9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
     devDependencies:
       '@autoview/agent':
         specifier: workspace:^
@@ -1939,8 +1939,8 @@ packages:
       vite:
         optional: true
 
-  '@samchon/openapi@3.2.4':
-    resolution: {integrity: sha512-vHIBWVLHgMdPGuEQfsvPliO+brYv2K9rXgn+aTJNHsOEWU6Yy8KHC2nL97R74Uqrm6EFGx82fnD/d/rbHp0ifg==}
+  '@samchon/openapi@4.0.0':
+    resolution: {integrity: sha512-fzji+KTrLqb3rD6RZID7N1cTN7aDwd0KAq0fP4rl2p1dHEy3uybqS7bP9BjMWP10k0DvFaS+P+g8+a/PA0FyZw==}
 
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
@@ -5269,6 +5269,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  quansync@0.2.10:
+    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
+
   quansync@0.2.8:
     resolution: {integrity: sha512-4+saucphJMazjt7iOM27mbFCk+D9dd/zmgMDCzRZ8MEoBfYp7lAvoN38et/phRQF6wOPMy/OROBGgoWeSKyluA==}
 
@@ -6094,11 +6097,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@8.1.1:
-    resolution: {integrity: sha512-R8iLPX52/tY/C/Ff7RhSsiV56JR21jLKbt1CShlrhKIJ6xoGejbXq8+y9RR/vLOo5WmZXi88yb2/zDHWyms2BQ==}
+  typia@9.0.1:
+    resolution: {integrity: sha512-ubx0/jugX1PbNT07jpKI/7+eW4RSe3t9QueIqFDza2Dpmfgb3Epa/YY0IDkLWshzXV1/OjBQh8cADM617xDUnw==}
     hasBin: true
     peerDependencies:
-      '@samchon/openapi': '>=3.2.2 <4.0.0'
+      '@samchon/openapi': '>=4.0.0 <5.0.0'
       typescript: '>=4.8.0 <5.9.0'
 
   ufo@1.5.4:
@@ -7873,7 +7876,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
-  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
       consola: 3.4.2
@@ -7885,14 +7888,14 @@ snapshots:
       pkg-types: 2.1.0
       type-fest: 4.37.0
       typescript: 5.8.2
-      typia: 8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2)
+      typia: 9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2)
       unplugin: 2.2.2
     optionalDependencies:
       vite: 6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - rollup
 
-  '@samchon/openapi@3.2.4': {}
+  '@samchon/openapi@4.0.0': {}
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -9880,8 +9883,8 @@ snapshots:
       '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.22.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.22.0(jiti@2.4.2))
@@ -9900,7 +9903,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -9911,22 +9914,22 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@9.22.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -9937,7 +9940,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.22.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@9.22.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2)))(eslint@9.22.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11984,7 +11987,7 @@ snapshots:
 
   package-manager-detector@0.2.11:
     dependencies:
-      quansync: 0.2.8
+      quansync: 0.2.10
 
   parent-module@1.0.1:
     dependencies:
@@ -12149,6 +12152,8 @@ snapshots:
       punycode: 2.3.1
 
   punycode@2.3.1: {}
+
+  quansync@0.2.10: {}
 
   quansync@0.2.8: {}
 
@@ -13225,9 +13230,9 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typia@8.1.1(@samchon/openapi@3.2.4)(typescript@5.8.2):
+  typia@9.0.1(@samchon/openapi@4.0.0)(typescript@5.8.2):
     dependencies:
-      '@samchon/openapi': 3.2.4
+      '@samchon/openapi': 4.0.0
       commander: 10.0.1
       comment-json: 4.2.5
       inquirer: 8.2.6

--- a/test/package.json
+++ b/test/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@nestia/e2e": "^0.8.2",
-    "@samchon/openapi": "^3.2.4",
+    "@samchon/openapi": "^4.0.0",
     "chalk": "4.1.2",
     "dotenv": "^16.4.7",
     "dotenv-expand": "^12.0.1",
@@ -23,7 +23,7 @@
     "rollup": "^4.34.1",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^8.1.1"
+    "typia": "^9.0.1"
   },
   "devDependencies": {
     "@autoview/agent": "workspace:^",


### PR DESCRIPTION
This pull request includes several updates to dependencies across multiple packages, as well as a minor version bump for the main package. The most important changes include updating the `@samchon/openapi` and `typia` dependencies to their latest versions, and modifying the `AutoViewSchemaProgrammer` to handle schema minimum values.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `6.0.0` to `6.1.0`.
* `packages/agent/package.json`, `packages/compiler/package.json`, `packages/interface/package.json`, `test/package.json`: Updated `@samchon/openapi` from `^3.2.4` to `^4.0.0` and `typia` from `^8.1.1` to `^9.0.1`. [[1]](diffhunk://#diff-f0f4adde46deb8e106c88cfb5dbf48155b8261ff0d73ada3429381a40e9bb3baL41-R44) [[2]](diffhunk://#diff-11f1c967e7b88e8bb1ad9292bc77da6ad6ac034c264ce56eed069eb1e19865deL16-R20) [[3]](diffhunk://#diff-d2327fdda1c4889df8f7c8e399de581131b8df453d232fad4e976f706607e2d0L26-R27) [[4]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL18-R26)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL45-R55): Updated various dependencies and their versions to reflect the changes in `@samchon/openapi` and `typia`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL45-R55) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL91-R92) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL103-R104) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL137-R145) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL183-R187) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL337-R338) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL361-R362) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1942-R1943) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5272-R5274) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6097-R6104) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7876-R7879) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7888-R7898) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9883-R9887) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9903-R9906) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9914-R9932) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9940-R9943) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11987-R11990) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR12156-R12157) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13228-R13235)

Code modification:

* [`packages/compiler/src/programmers/AutoViewSchemaProgrammer.ts`](diffhunk://#diff-27f85ea06a1d01ff6dddf2c53b38a0cf172f8a556764b1f4cf08c52e61d85be8L114-R118): Modified the `AutoViewSchemaProgrammer` to handle schema minimum values, ensuring proper tagging of `uint32` or `int32` based on the schema's minimum value.