### PR TITLE
fix(agent): claude schema inverter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@autoview/station",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Automatic viewer components renderer by JSON schema and AI agent",
   "repository": {
     "type": "git",

--- a/packages/compiler/src/AutoViewCompiler.ts
+++ b/packages/compiler/src/AutoViewCompiler.ts
@@ -4,7 +4,7 @@ import type {
   IAutoViewCompilerResult,
 } from "@autoview/interface";
 import { OpenApi } from "@samchon/openapi";
-import { ChatGptSchemaComposer } from "@samchon/openapi/lib/composers/llm/ChatGptSchemaComposer";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 import ts from "typescript";
 
 import { TypeScriptCompiler } from "./compilers/TypeScriptCompiler";
@@ -140,12 +140,12 @@ const getJsonSchema = (
     schemas: {},
   };
   const schema: OpenApi.IJsonSchema = isClaudeParameters(props)
-    ? ChatGptSchemaComposer.invert({
+    ? LlmSchemaComposer.invert("claude")({
         components,
         $defs: props.parameters.$defs,
         schema: props.parameters,
       })
-    : ChatGptSchemaComposer.invert({
+    : LlmSchemaComposer.invert("chatgpt")({
         components,
         $defs: props.$defs,
         schema: props.schema,


### PR DESCRIPTION
This pull request includes changes to the `packages/compiler/src/AutoViewCompiler.ts` file to update the schema composer used in the code. The most important changes involve replacing the `ChatGptSchemaComposer` with the `LlmSchemaComposer` to handle different types of schema inversions.

Schema composer updates:

* [`packages/compiler/src/AutoViewCompiler.ts`](diffhunk://#diff-76595d8739437eabd122e2e7d8648ed62f3e00f325232ab459e53b8fb6c8feb7L7-R7): Replaced the import of `ChatGptSchemaComposer` with `LlmSchemaComposer` to use a more generic schema composer.
* [`packages/compiler/src/AutoViewCompiler.ts`](diffhunk://#diff-76595d8739437eabd122e2e7d8648ed62f3e00f325232ab459e53b8fb6c8feb7L143-R148): Updated the `getJsonSchema` function to use `LlmSchemaComposer.invert("claude")` and `LlmSchemaComposer.invert("chatgpt")` instead of `ChatGptSchemaComposer.invert`.