### PR TITLE
fix(agent): wrong schema inversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@autoview/station",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Automatic viewer components renderer by JSON schema and AI agent",
   "repository": {
     "type": "git",

--- a/packages/agent/src/agents/AutoViewAgent.ts
+++ b/packages/agent/src/agents/AutoViewAgent.ts
@@ -180,11 +180,8 @@ export class AutoViewAgent {
           break;
         }
       }
-
       return {
-        components: {
-          schemas: converted.components,
-        },
+        components: converted.components,
         schema: converted.schema,
       } satisfies IAutoViewCompilerMetadata;
     } else if (this.config.input.type === "parameters") {
@@ -235,11 +232,8 @@ export class AutoViewAgent {
           break;
         }
       }
-
       return {
-        components: {
-          schemas: converted.components,
-        },
+        components: converted.components,
         schema: converted.schema,
       } satisfies IAutoViewCompilerMetadata;
     } else {

--- a/packages/agent/src/agents/convert-schema.ts
+++ b/packages/agent/src/agents/convert-schema.ts
@@ -12,7 +12,7 @@ import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaCompo
 
 export interface ConvertedSchema {
   schema: OpenApi.IJsonSchema;
-  components: Record<string, OpenApi.IJsonSchema>;
+  components: OpenApi.IComponents;
 }
 
 export function convertSchema<Model extends ILlmSchema.Model>(


### PR DESCRIPTION
This pull request includes several changes to the `@autoview/station` package to update the version and improve the handling of schema components in the `AutoViewAgent` class. The most important changes include updating the package version, simplifying the return structure in the `AutoViewAgent` class, and adjusting the type of `components` in the `ConvertedSchema` interface.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `7.1.0` to `7.1.1`.

Improvements to schema handling:

* [`packages/agent/src/agents/AutoViewAgent.ts`](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L183-R184): Simplified the return structure by removing the nested `components` object and directly assigning `converted.components` to `components`. [[1]](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L183-R184) [[2]](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L238-R236)
* [`packages/agent/src/agents/convert-schema.ts`](diffhunk://#diff-d1933e5e07add535963f1fa4316ed99af635c02c703b023bcca47e87ac888659L15-R15): Changed the type of `components` in the `ConvertedSchema` interface from `Record<string, OpenApi.IJsonSchema>` to `OpenApi.IComponents`.