### PR TITLE
Fix ui components type builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@autoview/station",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Automatic viewer components renderer by JSON schema and AI agent",
   "repository": {
     "type": "git",

--- a/packages/agent/src/agents/AutoViewAgent.ts
+++ b/packages/agent/src/agents/AutoViewAgent.ts
@@ -2,7 +2,7 @@ import {
   IAutoViewCompilerMetadata,
   IAutoViewComponentProps,
 } from "@autoview/interface";
-import { type ILlmSchema, OpenApiTypeChecker } from "@samchon/openapi";
+import { type ILlmSchema } from "@samchon/openapi";
 import typia, { type IJsonSchemaUnit } from "typia";
 
 import { AllInOne, CodeGeneration, PlanGeneration } from "../passes";
@@ -315,22 +315,15 @@ export class AutoViewAgent {
 }
 
 function componentSchema(): IAutoViewCompilerMetadata {
-  if (!OpenApiTypeChecker.isObject(PARAMETERS)) {
-    throw new Error("PARAMETERS is not an object.");
-  }
-
-  return {
-    $defs: PARAMETERS.$defs,
-    schema: PARAMETERS.properties["props"]!,
-  };
+  return typia.json.schema<IAutoViewComponentProps>();
 }
 
-const PARAMETERS = typia.llm.parameters<
-  {
-    props: IAutoViewComponentProps;
-  },
-  "chatgpt",
-  {
-    reference: true;
-  }
->();
+// const PARAMETERS = typia.llm.parameters<
+//   {
+//     props: IAutoViewComponentProps;
+//   },
+//   "chatgpt",
+//   {
+//     reference: true;
+//   }
+// >();


### PR DESCRIPTION
This pull request includes version updates and code simplifications for the `AutoViewAgent` class. The most important changes involve updating the package version, removing an unused import, and simplifying the `componentSchema` function.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `7.1.1` to `7.1.2`.

Code simplifications:

* [`packages/agent/src/agents/AutoViewAgent.ts`](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L5-R5): Removed the `OpenApiTypeChecker` import as it was not being used.
* [`packages/agent/src/agents/AutoViewAgent.ts`](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L318-R329): Simplified the `componentSchema` function by removing the check for `PARAMETERS` and directly returning the schema using `typia.json.schema<IAutoViewComponentProps>()`.