### PR TITLE
feat(website): unify footer on landing and document

### DIFF
--- a/website/app/layout.jsx
+++ b/website/app/layout.jsx
@@ -1,9 +1,10 @@
-import { Footer, Layout, Navbar } from "nextra-theme-docs";
+import { Layout, Navbar } from "nextra-theme-docs";
 // Required for theme styles, previously was imported under the hood
 import "nextra-theme-docs/style.css";
 import { Head } from "nextra/components";
 import { getPageMap } from "nextra/page-map";
 
+import Footer from "./_components/layout/Footer";
 import "./globals.css";
 
 export const metadata = {
@@ -16,11 +17,6 @@ const navbar = (
     logo={<b>Autoview</b>}
     projectLink="https://github.com/wrtnlabs/autoview"
   />
-);
-const footer = (
-  <Footer className="flex-col items-center md:items-start">
-    MIT {new Date().getFullYear()} © Wrtn Technologies.
-  </Footer>
 );
 
 export default async function RootLayout(props) {
@@ -89,12 +85,12 @@ export default async function RootLayout(props) {
           docsRepositoryBase="https://github.com/wrtnlabs/autoview/tree/main/website"
           editLink="Edit this page on GitHub"
           sidebar={{ defaultMenuCollapseLevel: 1 }}
-          footer={footer}
+          footer={<Footer />}
           nextThemes={{
             defaultTheme: "dark",
           }}
           darkMode={false}
-        // ...Your additional theme config options
+          // ...Your additional theme config options
         >
           {props.children}
         </Layout>


### PR DESCRIPTION
after:
<img width="1449" alt="스크린샷 2025-04-13 오후 6 06 13" src="https://github.com/user-attachments/assets/f770a280-c507-43fe-a310-9c3b88547358" />

---

This pull request includes changes to the `website/app/layout.jsx` file to modify the way the `Footer` component is imported and used. The most important changes include removing the `Footer` import from `nextra-theme-docs` and using a custom `Footer` component instead.

Changes to `Footer` component usage:

* [`website/app/layout.jsx`](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99L1-R7): Removed the `Footer` import from `nextra-theme-docs` and added a custom `Footer` import from `./_components/layout/Footer`.
* [`website/app/layout.jsx`](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99L20-L24): Removed the `footer` constant definition and directly used the custom `Footer` component in the `RootLayout` function. [[1]](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99L20-L24) [[2]](diffhunk://#diff-b43b1bc0a42db021ecb816f80baa2348806164da1b99c2584eed456d5f7c2e99L92-R88)