### PR TITLE
Bump up `@samchon/openapi` for DeepSeek supporting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@autoview/station",
-  "version": "7.2.3",
+  "version": "7.3.0",
   "description": "Automatic viewer components renderer by JSON schema and AI agent",
   "repository": {
     "type": "git",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -38,9 +38,9 @@
   "dependencies": {
     "@autoview/compiler": "workspace:^",
     "@autoview/interface": "workspace:^",
-    "@samchon/openapi": "^4.0.0",
+    "@samchon/openapi": "^4.1.0",
     "jsonpath-plus": "^10.3.0",
     "openai": "^4.90.0",
-    "typia": "^9.1.0"
+    "typia": "^9.1.1"
   }
 }

--- a/packages/agent/src/agents/AutoViewAgent.ts
+++ b/packages/agent/src/agents/AutoViewAgent.ts
@@ -35,12 +35,14 @@ export type IAutoViewInput =
   | IAutoViewJsonSchemaInput
   | IAutoViewLlmSchemaInput<"chatgpt">
   | IAutoViewLlmSchemaInput<"claude">
+  | IAutoViewLlmSchemaInput<"deepseek">
   | IAutoViewLlmSchemaInput<"gemini">
   | IAutoViewLlmSchemaInput<"llama">
   | IAutoViewLlmSchemaInput<"3.0">
   | IAutoViewLlmSchemaInput<"3.1">
   | IAutoViewParametersInput<"chatgpt">
   | IAutoViewParametersInput<"claude">
+  | IAutoViewParametersInput<"deepseek">
   | IAutoViewParametersInput<"gemini">
   | IAutoViewParametersInput<"llama">
   | IAutoViewParametersInput<"3.0">
@@ -144,7 +146,10 @@ export class AutoViewAgent {
           );
           break;
         }
-        case "claude": {
+        case "claude":
+        case "deepseek":
+        case "llama":
+        case "3.1": {
           converted = convertSchema<"claude">(
             "claude",
             this.config.input.schema,
@@ -160,25 +165,9 @@ export class AutoViewAgent {
           );
           break;
         }
-        case "llama": {
-          converted = convertSchema<"llama">(
-            "llama",
-            this.config.input.schema,
-            this.config.input.$defs,
-          );
-          break;
-        }
         case "3.0": {
           converted = convertSchema<"3.0">(
             "3.0",
-            this.config.input.schema,
-            this.config.input.$defs,
-          );
-          break;
-        }
-        case "3.1": {
-          converted = convertSchema<"3.1">(
-            "3.1",
             this.config.input.schema,
             this.config.input.$defs,
           );
@@ -201,7 +190,10 @@ export class AutoViewAgent {
           );
           break;
         }
-        case "claude": {
+        case "claude":
+        case "deepseek":
+        case "llama":
+        case "3.1": {
           converted = convertSchema<"claude">(
             "claude",
             this.config.input.parameters,
@@ -216,24 +208,8 @@ export class AutoViewAgent {
           );
           break;
         }
-        case "llama": {
-          converted = convertSchema<"llama">(
-            "llama",
-            this.config.input.parameters,
-            this.config.input.parameters.$defs,
-          );
-          break;
-        }
         case "3.0": {
           converted = convertSchema<"3.0">("3.0", this.config.input.parameters);
-          break;
-        }
-        case "3.1": {
-          converted = convertSchema<"3.1">(
-            "3.1",
-            this.config.input.parameters,
-            this.config.input.parameters.$defs,
-          );
           break;
         }
       }

--- a/packages/agent/src/agents/convert-schema.ts
+++ b/packages/agent/src/agents/convert-schema.ts
@@ -2,10 +2,8 @@ import {
   IChatGptSchema,
   IClaudeSchema,
   IGeminiSchema,
-  ILlamaSchema,
   ILlmSchema,
   ILlmSchemaV3,
-  ILlmSchemaV3_1,
   OpenApi,
 } from "@samchon/openapi";
 import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
@@ -27,24 +25,17 @@ export function convertSchema<Model extends ILlmSchema.Model>(
         ($defs ?? {}) as unknown as Record<string, IChatGptSchema>,
       );
     case "claude":
+    case "deepseek":
+    case "llama":
+    case "3.1":
       return convertSchemaFromClaudeSchema(
         schema as IClaudeSchema,
         ($defs ?? {}) as unknown as Record<string, IClaudeSchema>,
       );
     case "gemini":
       return convertSchemaFromGeminiSchema(schema as IGeminiSchema);
-    case "llama":
-      return convertSchemaFromLlamaSchema(
-        schema as ILlamaSchema,
-        ($defs ?? {}) as unknown as Record<string, ILlamaSchema>,
-      );
     case "3.0":
       return convertSchemaFromLlmSchemaV3(schema as ILlmSchemaV3);
-    case "3.1":
-      return convertSchemaFromLlmSchemaV3_1(
-        schema as ILlmSchemaV3_1,
-        ($defs ?? {}) as unknown as Record<string, ILlmSchemaV3_1>,
-      );
     default:
       throw new Error(`the model ${model} is unsupported`);
   }
@@ -97,23 +88,6 @@ export function convertSchemaFromGeminiSchema(
   };
 }
 
-export function convertSchemaFromLlamaSchema(
-  schema: ILlamaSchema,
-  $defs: Record<string, ILlamaSchema>,
-): ConvertedSchema {
-  const components: Record<string, OpenApi.IJsonSchema> = {};
-  const result = LlmSchemaComposer.invert("llama")({
-    schema,
-    $defs,
-    components,
-  });
-
-  return {
-    schema: result,
-    components,
-  };
-}
-
 export function convertSchemaFromLlmSchemaV3(
   schema: ILlmSchemaV3,
 ): ConvertedSchema {
@@ -124,22 +98,5 @@ export function convertSchemaFromLlmSchemaV3(
   return {
     schema: result,
     components: {},
-  };
-}
-
-export function convertSchemaFromLlmSchemaV3_1(
-  schema: ILlmSchemaV3_1,
-  $defs: Record<string, ILlmSchemaV3_1>,
-): ConvertedSchema {
-  const components: Record<string, OpenApi.IJsonSchema> = {};
-  const result = LlmSchemaComposer.invert("3.1")({
-    schema,
-    $defs,
-    components,
-  });
-
-  return {
-    schema: result,
-    components,
   };
 }

--- a/packages/compiler-browser-test/package.json
+++ b/packages/compiler-browser-test/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^19.0.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^9.1.0"
+    "typia": "^9.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@autoview/interface": "workspace:^",
-    "@samchon/openapi": "^4.0.0",
+    "@samchon/openapi": "^4.1.0",
     "serialize-error": "4.1.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^9.1.0"
+    "typia": "^9.1.1"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -23,8 +23,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@samchon/openapi": "^4.0.0",
-    "typia": "^9.1.0"
+    "@samchon/openapi": "^4.1.0",
+    "typia": "^9.1.1"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: workspace:^
         version: link:../interface
       '@samchon/openapi':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^4.1.0
+        version: 4.1.0
       jsonpath-plus:
         specifier: ^10.3.0
         version: 10.3.0
@@ -51,8 +51,8 @@ importers:
         specifier: ^4.90.0
         version: 4.90.0(ws@8.18.1)(zod@3.24.2)
       typia:
-        specifier: ^9.1.0
-        version: 9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2)
+        specifier: ^9.1.1
+        version: 9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.13.9
@@ -88,8 +88,8 @@ importers:
         specifier: workspace:^
         version: link:../interface
       '@samchon/openapi':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^4.1.0
+        version: 4.1.0
       serialize-error:
         specifier: 4.1.0
         version: 4.1.0
@@ -100,8 +100,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.1.0
-        version: 9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2)
+        specifier: ^9.1.1
+        version: 9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -134,15 +134,15 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.1.0
-        version: 9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2)
+        specifier: ^9.1.1
+        version: 9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2)
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.22.0
       '@ryoppippi/unplugin-typia':
         specifier: ^2.1.4
-        version: 2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))
+        version: 2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.11
@@ -180,11 +180,11 @@ importers:
   packages/interface:
     dependencies:
       '@samchon/openapi':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^4.1.0
+        version: 4.1.0
       typia:
-        specifier: ^9.1.0
-        version: 9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2)
+        specifier: ^9.1.1
+        version: 9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2)
     devDependencies:
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.7.2
@@ -266,7 +266,7 @@ importers:
         version: 8.6.7(storybook@8.6.7(prettier@3.5.3))
       '@storybook/blocks':
         specifier: ^8.6.4
-        version: 8.6.7(react-dom@17.0.2(react@19.0.0))(react@17.0.2)(storybook@8.6.7(prettier@3.5.3))
+        version: 8.6.7(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.7(prettier@3.5.3))
       '@storybook/experimental-addon-test':
         specifier: ^8.6.4
         version: 8.6.7(@vitest/browser@3.0.9)(@vitest/runner@3.0.9)(react-dom@17.0.2(react@19.0.0))(react@17.0.2)(storybook@8.6.7(prettier@3.5.3))(vitest@3.0.9)
@@ -346,8 +346,8 @@ importers:
         specifier: ^0.8.2
         version: 0.8.3
       '@samchon/openapi':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^4.1.0
+        version: 4.1.0
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -370,8 +370,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.1.0
-        version: 9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2)
+        specifier: ^9.1.1
+        version: 9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2)
     devDependencies:
       '@autoview/agent':
         specifier: workspace:^
@@ -1948,8 +1948,8 @@ packages:
       vite:
         optional: true
 
-  '@samchon/openapi@4.0.0':
-    resolution: {integrity: sha512-fzji+KTrLqb3rD6RZID7N1cTN7aDwd0KAq0fP4rl2p1dHEy3uybqS7bP9BjMWP10k0DvFaS+P+g8+a/PA0FyZw==}
+  '@samchon/openapi@4.1.0':
+    resolution: {integrity: sha512-UUFBI6n8R9+V0xt4scGEaQ0rib04cOVARhu7DXBZuEG0ExiTFPoiW49+qYFwE44LjYpfxBIlNkd+rcpiRGhsNA==}
 
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
@@ -6170,8 +6170,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@9.1.0:
-    resolution: {integrity: sha512-cUMYicsrQ8UitYDHmoWKcUQYaNwzbj+SN57zSIkU1kpTQZeFcFdLXLIS+JIyrtqVVY7GiaDDA5t4lSqwhWw/Bg==}
+  typia@9.1.1:
+    resolution: {integrity: sha512-fMgrd2VLGZoDjZZwWlgriotUiG38UEzcMD0ToJOhQ0bPr966mit0ZEy5TnDhm2RidXfejZOqHb7iOoTG3VHd4w==}
     hasBin: true
     peerDependencies:
       '@samchon/openapi': '>=4.0.0 <5.0.0'
@@ -7953,7 +7953,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.11.0': {}
 
-  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))':
+  '@ryoppippi/unplugin-typia@2.1.4(rollup@4.36.0)(typescript@5.8.2)(typia@9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2))(vite@6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.36.0)
       consola: 3.4.2
@@ -7965,14 +7965,14 @@ snapshots:
       pkg-types: 2.1.0
       type-fest: 4.37.0
       typescript: 5.8.2
-      typia: 9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2)
+      typia: 9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2)
       unplugin: 2.2.2
     optionalDependencies:
       vite: 6.2.2(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - rollup
 
-  '@samchon/openapi@4.0.0': {}
+  '@samchon/openapi@4.1.0': {}
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -8103,9 +8103,9 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.7(prettier@3.5.3)
 
-  '@storybook/blocks@8.6.7(react-dom@17.0.2(react@19.0.0))(react@17.0.2)(storybook@8.6.7(prettier@3.5.3))':
+  '@storybook/blocks@8.6.7(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@8.6.7(prettier@3.5.3))':
     dependencies:
-      '@storybook/icons': 1.4.0(react-dom@17.0.2(react@19.0.0))(react@17.0.2)
+      '@storybook/icons': 1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       storybook: 8.6.7(prettier@3.5.3)
       ts-dedent: 2.2.0
     optionalDependencies:
@@ -8162,7 +8162,7 @@ snapshots:
   '@storybook/experimental-addon-test@8.6.7(@vitest/browser@3.0.9)(@vitest/runner@3.0.9)(react-dom@17.0.2(react@19.0.0))(react@17.0.2)(storybook@8.6.7(prettier@3.5.3))(vitest@3.0.9)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 1.4.0(react-dom@17.0.2(react@19.0.0))(react@17.0.2)
+      '@storybook/icons': 1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/instrumenter': 8.6.7(storybook@8.6.7(prettier@3.5.3))
       '@storybook/test': 8.6.7(storybook@8.6.7(prettier@3.5.3))
       polished: 4.3.1
@@ -8179,7 +8179,7 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.4.0(react-dom@17.0.2(react@19.0.0))(react@17.0.2)':
+  '@storybook/icons@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@19.0.0)
@@ -13402,9 +13402,9 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typia@9.1.0(@samchon/openapi@4.0.0)(typescript@5.8.2):
+  typia@9.1.1(@samchon/openapi@4.1.0)(typescript@5.8.2):
     dependencies:
-      '@samchon/openapi': 4.0.0
+      '@samchon/openapi': 4.1.0
       commander: 10.0.1
       comment-json: 4.2.5
       inquirer: 8.2.6

--- a/test/package.json
+++ b/test/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@nestia/e2e": "^0.8.2",
-    "@samchon/openapi": "^4.0.0",
+    "@samchon/openapi": "^4.1.0",
     "chalk": "4.1.2",
     "dotenv": "^16.4.7",
     "dotenv-expand": "^12.0.1",
@@ -23,7 +23,7 @@
     "rollup": "^4.34.1",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^9.1.0"
+    "typia": "^9.1.1"
   },
   "devDependencies": {
     "@autoview/agent": "workspace:^",


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple files, focusing on version upgrades and the addition of support for new schema types in the `AutoViewAgent`.

### Version Upgrades:
* Updated the `@samchon/openapi` dependency from version `4.0.0` to `4.1.0` in multiple `package.json` files and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-f0f4adde46deb8e106c88cfb5dbf48155b8261ff0d73ada3429381a40e9bb3baL41-R44) [[2]](diffhunk://#diff-11f1c967e7b88e8bb1ad9292bc77da6ad6ac034c264ce56eed069eb1e19865deL16-R20) [[3]](diffhunk://#diff-d2327fdda1c4889df8f7c8e399de581131b8df453d232fad4e976f706607e2d0L26-R27) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL45-R55) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL91-R92) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL103-R104) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL137-R145) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL349-R350) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL373-R374) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1951-R1952) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7956-R7956) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7968-R7975) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8165-R8165) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8182-R8182) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13405-R13407)
* Updated the `typia` dependency from version `9.1.0` to `9.1.1` in multiple `package.json` files and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-f0f4adde46deb8e106c88cfb5dbf48155b8261ff0d73ada3429381a40e9bb3baL41-R44) [[2]](diffhunk://#diff-88a132e046e068cee428485779b13db3569487d95751d7bcb1719300dc9bd012L20-R20) [[3]](diffhunk://#diff-11f1c967e7b88e8bb1ad9292bc77da6ad6ac034c264ce56eed069eb1e19865deL16-R20) [[4]](diffhunk://#diff-d2327fdda1c4889df8f7c8e399de581131b8df453d232fad4e976f706607e2d0L26-R27) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL45-R55) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL91-R92) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL103-R104) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL137-R145) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL373-R374) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6173-R6174) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7956-R7956) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7968-R7975) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13405-R13407)

### Schema Support Additions:
* Added support for `deepseek` schema types in `AutoViewAgent` and `convert-schema.ts`. This includes adding `deepseek` to the `IAutoViewInput` type and updating the `convertSchema` function to handle `deepseek` schemas. [[1]](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583R38-R45) [[2]](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L147-R152) [[3]](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L204-R196) [[4]](diffhunk://#diff-d1933e5e07add535963f1fa4316ed99af635c02c703b023bcca47e87ac888659R28-L47)

### Schema Support Removals:
* Removed support for `llama` and `3.1` schema types from `AutoViewAgent` and `convert-schema.ts`. This includes removing these types from the `IAutoViewInput` type and updating the `convertSchema` function to no longer handle these schemas. [[1]](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L163-L170) [[2]](diffhunk://#diff-942e5ed7f04aa57cb2367330983ab4f378fce07146ac065eb49bd901170d7583L179-L186) [[3]](diffhunk://#diff-d1933e5e07add535963f1fa4316ed99af635c02c703b023bcca47e87ac888659R28-L47) [[4]](diffhunk://#diff-d1933e5e07add535963f1fa4316ed99af635c02c703b023bcca47e87ac888659L100-L116) [[5]](diffhunk://#diff-d1933e5e07add535963f1fa4316ed99af635c02c703b023bcca47e87ac888659L129-L145)

### Miscellaneous:
* Bumped the version of the `@autoview/station` package from `7.2.3` to `7.3.0` in `package.json`.