### PR TITLE
Multi-turn support

### DIFF
--- a/test/src/features/test_main_agent.ts
+++ b/test/src/features/test_main_agent.ts
@@ -24,7 +24,7 @@ export async function test_main_agent(): Promise<void> {
       parameters: schema,
     },
   });
-  const result = await agent.generate();
+  const result = await agent.generate(undefined);
 
   if (result.status === "success") {
     console.log(result.tsxCode);


### PR DESCRIPTION
This PR enables the AutoView Chat agent to handle multi-turn request, by proceeding assistant's turn further if there was any tool result after processing a single turn.

Also, this PR includes correction of capturing streaming LLM events.